### PR TITLE
feat: replace OpenAI Whisper with local NVIDIA Parakeet transcription

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,10 +7,6 @@ POSTGRES_DB=memoctopus
 HF_TOKEN=
 VLLM_MODEL=Qwen/Qwen3-0.6B
 
-# OpenAI Configuration (for audio transcription)
-OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_BASE_URL=https://api.openai.com/v1
-
 # Frontend Configuration (optional - defaults work for Docker)
 # BACKEND_URL is used for Next.js proxy, defaults to http://backend:8000 in Docker
 # For local development without Docker, set BACKEND_URL=http://localhost:8002

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - huggingface_cache:/root/.cache/huggingface
     ports:
       - "8001:8000"
-    command: --model ${VLLM_MODEL:-Qwen/Qwen3-0.6B} --gpu-memory-utilization 0.25 --max-num-seqs 32
+    command: --model ${VLLM_MODEL:-Qwen/Qwen3-0.6B} --gpu-memory-utilization 0.5 --max-num-seqs 32
     ipc: host
     deploy:
       resources:
@@ -42,6 +42,27 @@ services:
       - memoctopus-network
     restart: unless-stopped
 
+  transcription:
+    build:
+      context: ./transcription
+      dockerfile: Dockerfile
+    container_name: memoctopus-transcription
+    runtime: nvidia
+    volumes:
+      - nemo_cache:/root/.cache
+    ports:
+      - "8003:8000"
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    networks:
+      - memoctopus-network
+    restart: unless-stopped
+
   backend:
     build:
       context: ./backend
@@ -49,8 +70,7 @@ services:
     container_name: memoctopus-backend
     environment:
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-memoctopus}?sslmode=disable
-      OPENAI_API_KEY: ${OPENAI_API_KEY}
-      OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      TRANSCRIPTION_BASE_URL: http://transcription:8000
       VLLM_BASE_URL: http://vllm:8000/v1
       VLLM_MODEL: ${VLLM_MODEL:-Qwen/Qwen3-0.6B}
     ports:
@@ -59,6 +79,8 @@ services:
       postgres:
         condition: service_healthy
       vllm:
+        condition: service_started
+      transcription:
         condition: service_started
     networks:
       - memoctopus-network
@@ -87,6 +109,7 @@ services:
 volumes:
   postgres_data:
   huggingface_cache:
+  nemo_cache:
 
 networks:
   memoctopus-network:

--- a/transcription/Dockerfile
+++ b/transcription/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12-slim-bookworm
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libsndfile1 \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Install PyTorch with CUDA 12.4 support first
+RUN pip install --no-cache-dir torch torchaudio --index-url https://download.pytorch.org/whl/cu124
+
+# Install NeMo ASR toolkit and web framework
+RUN pip install --no-cache-dir \
+    'nemo_toolkit[asr]' \
+    fastapi \
+    'uvicorn[standard]' \
+    python-multipart
+
+COPY main.py .
+
+EXPOSE 8000
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/transcription/main.py
+++ b/transcription/main.py
@@ -1,0 +1,128 @@
+import os
+import tempfile
+import subprocess
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Optional
+
+from fastapi import FastAPI, File, Form, UploadFile
+from fastapi.responses import JSONResponse
+
+model = None
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    global model
+    import nemo.collections.asr as nemo_asr
+
+    print("Loading NVIDIA Parakeet RNNT 110M Danish model...")
+    model = nemo_asr.models.ASRModel.from_pretrained(
+        model_name="nvidia/parakeet-rnnt-110m-da-dk"
+    )
+    model.eval()
+    print("Model loaded successfully.")
+    yield
+
+
+app = FastAPI(lifespan=lifespan)
+
+
+def convert_to_wav(input_path: str, output_path: str):
+    """Convert audio to 16kHz mono WAV using ffmpeg."""
+    subprocess.run(
+        [
+            "ffmpeg",
+            "-i",
+            input_path,
+            "-ar",
+            "16000",
+            "-ac",
+            "1",
+            "-f",
+            "wav",
+            output_path,
+            "-y",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+
+def do_transcribe(audio_path: str, timestamps: bool = False) -> dict:
+    """Transcribe audio file. Runs synchronously (call from thread pool)."""
+    output = model.transcribe(
+        [audio_path], return_hypotheses=timestamps, timestamps=timestamps
+    )
+    hyp = output[0]
+
+    if not timestamps:
+        text = hyp.text if hasattr(hyp, "text") else str(hyp)
+        return {"text": text}
+
+    # With return_hypotheses=True, output may be nested [[Hypothesis]]
+    if isinstance(hyp, list):
+        hyp = hyp[0]
+
+    result = {"text": hyp.text}
+
+    # Word-level timestamps and confidence
+    if hasattr(hyp, "words") and hyp.words:
+        words = []
+        confidences_raw = getattr(hyp, "word_confidence", None)
+        confidences = list(confidences_raw) if confidences_raw is not None and len(confidences_raw) > 0 else []
+        for i, word in enumerate(hyp.words):
+            entry = {"word": word}
+            if i < len(confidences):
+                entry["confidence"] = round(confidences[i], 3)
+            words.append(entry)
+        result["words"] = words
+
+    # Timestamp dict (segment/word/char level)
+    ts = getattr(hyp, "timestamp", None) or getattr(hyp, "timestep", None)
+    if ts and isinstance(ts, dict):
+        if "segment" in ts:
+            result["segments"] = ts["segment"]
+        if "word" in ts:
+            result["word_timestamps"] = ts["word"]
+
+    return result
+
+
+@app.post("/v1/audio/transcriptions")
+async def transcribe(
+    file: UploadFile = File(...),
+    model: Optional[str] = Form(None),
+    stream: Optional[str] = Form(None),
+    timestamps: Optional[str] = Form(None),
+):
+    """
+    Transcribe audio using NVIDIA Parakeet RNNT 110M Danish model.
+    Accepts the same multipart form interface as OpenAI Whisper API.
+    Pass timestamps=true to get word-level and segment-level timestamps.
+    """
+    want_timestamps = timestamps and timestamps.lower() == "true"
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Save uploaded file
+        filename = file.filename or "audio"
+        input_path = os.path.join(tmpdir, filename)
+        with open(input_path, "wb") as f:
+            f.write(await file.read())
+
+        # Convert to 16kHz mono WAV (NeMo expects this format)
+        wav_path = os.path.join(tmpdir, "audio.wav")
+        convert_to_wav(input_path, wav_path)
+
+        # Transcribe in thread pool to avoid blocking the event loop
+        loop = asyncio.get_event_loop()
+        result = await loop.run_in_executor(
+            None, do_transcribe, wav_path, want_timestamps
+        )
+
+        return JSONResponse(content=result)
+
+
+@app.get("/health")
+async def health():
+    return {"status": "healthy", "model_loaded": model is not None}


### PR DESCRIPTION
Replace the OpenAI Whisper API dependency with a local GPU-based transcription service using NVIDIA's Parakeet RNNT 110M Danish model. This removes the need for an OpenAI API key and keeps all audio processing on-premise.

- Add transcription service (FastAPI + NeMo ASR on GPU)
- Support word-level and segment-level timestamps via timestamps=true
- Convert incoming audio to 16kHz mono WAV via ffmpeg
- Update backend to forward to local transcription container
- Remove OpenAI configuration from docker-compose and .env
- Increase vLLM gpu-memory-utilization to 0.5 for larger models