### PR TITLE
ci(workflow): add Docker build actions for GHCR

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build and Push Images
+
+on:
+  push:
+    branches: [ main ]
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
+
+    strategy:
+      matrix:
+        service: [backend, frontend, transcription]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set lower case owner name
+        run: |
+          echo "OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_ENV
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: ./${{ matrix.service }}
+          push: true
+          tags: |
+            ghcr.io/${{ env.OWNER_LC }}/memoctopus-${{ matrix.service }}:${{ github.sha }}
+            ghcr.io/${{ env.OWNER_LC }}/memoctopus-${{ matrix.service }}:main


### PR DESCRIPTION
This adds a GitHub Actions workflow that automatically builds and pushes the backend, frontend, and transcription images to [GHCR](https://github.com/orgs/OS2sandbox/packages?repo_name=memoctopus-mvp). 
Having public images of the newest custom builds makes memoctopus a lot easier deploy

- Uses SHA + main tags

Tested on direct fork https://github.com/HJK-Automatisering/memoctopus-mvp