### PR TITLE
feat: add nginx SSL reverse proxy and fix deployment issues

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -24,6 +24,14 @@ FROM python:3.12-slim-bookworm
 
 WORKDIR /app
 
+# Install WeasyPrint system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    libglib2.0-0 \
+    libpango-1.0-0 \
+    libpangocairo-1.0-0 \
+    libgdk-pixbuf-2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
 # Copy uv and dbmate from builder
 COPY --from=builder /bin/uv /bin/uv
 COPY --from=builder /bin/uvx /bin/uvx

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - huggingface_cache:/root/.cache/huggingface
     ports:
       - "8001:8000"
-    command: --model ${VLLM_MODEL:-openai/gpt-oss-20b} --gpu-memory-utilization 0.5 --max-num-seqs 32
+    command: --model ${VLLM_MODEL:-Qwen/Qwen3-0.6B} --gpu-memory-utilization 0.5 --max-num-seqs 32
     ipc: host
     deploy:
       resources:
@@ -50,7 +50,6 @@ services:
     runtime: nvidia
     environment:
       HF_TOKEN: ${HF_TOKEN:-}
-      STT_MODEL: ${STT_MODEL:-nvidia/parakeet-rnnt-110m-da-dk}
     volumes:
       - nemo_cache:/root/.cache
     ports:
@@ -100,11 +99,27 @@ services:
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
       MICROSOFT_CLIENT_ID: ${MICROSOFT_CLIENT_ID:-}
       MICROSOFT_CLIENT_SECRET: ${MICROSOFT_CLIENT_SECRET:-}
+      MICROSOFT_TENANT_ID: ${MICROSOFT_TENANT_ID:-}
       BACKEND_URL: http://backend:8000
-    ports:
-      - "80:3000"
+    expose:
+      - "3000"
     depends_on:
       - backend
+    networks:
+      - memoctopus-network
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:alpine
+    container_name: memoctopus-nginx
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./nginx/certs:/etc/nginx/certs:ro
+    depends_on:
+      - frontend
     networks:
       - memoctopus-network
     restart: unless-stopped

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -8,6 +8,11 @@ const nextConfig: NextConfig = {
   env: {
     APP_VERSION: packageJson.version,
   },
+  experimental: {
+    serverActions: {
+      bodySizeLimit: "100mb",
+    },
+  },
 };
 
 export default nextConfig;

--- a/frontend/src/lib/api/proxy.ts
+++ b/frontend/src/lib/api/proxy.ts
@@ -2,6 +2,17 @@ import { type NextRequest, NextResponse } from "next/server";
 
 const BACKEND_URL = process.env["BACKEND_URL"] || "http://localhost:8002";
 
+const HOP_BY_HOP_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
 export async function proxyToBackend(
   request: NextRequest,
   backendPath: string,
@@ -10,7 +21,7 @@ export async function proxyToBackend(
 
   const headers = new Headers();
   request.headers.forEach((value, key) => {
-    if (key.toLowerCase() !== "host") {
+    if (key.toLowerCase() !== "host" && !HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
       headers.set(key, value);
     }
   });

--- a/frontend/src/lib/api/proxy.ts
+++ b/frontend/src/lib/api/proxy.ts
@@ -21,7 +21,10 @@ export async function proxyToBackend(
 
   const headers = new Headers();
   request.headers.forEach((value, key) => {
-    if (key.toLowerCase() !== "host" && !HOP_BY_HOP_HEADERS.has(key.toLowerCase())) {
+    if (
+      key.toLowerCase() !== "host" &&
+      !HOP_BY_HOP_HEADERS.has(key.toLowerCase())
+    ) {
       headers.set(key, value);
     }
   });

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -11,24 +11,24 @@ export const auth = betterAuth({
   trustedOrigins: [
     "http://localhost:3000",
     "http://127.0.0.1:3000",
-    "https://pedro.sikkerai.dk",
     "http://10.1.3.10:6767",
+    "https://pedro.sikkerai.dk",
+    "http://taletiltekst.syddjurs.dk",
+    "https://taletiltekst.syddjurs.dk",
   ],
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,
     minPasswordLength: 8,
   },
-  // Temporarily disable social providers to isolate the issue
-  // socialProviders: process.env["MICROSOFT_CLIENT_ID"] && process.env["MICROSOFT_CLIENT_SECRET"] ? {
-  //   microsoft: {
-  //     clientId: process.env["MICROSOFT_CLIENT_ID"] as string,
-  //     clientSecret: process.env["MICROSOFT_CLIENT_SECRET"] as string,
-  //     tenantId: "common", // Use 'common' for multi-tenant, or specific tenant ID
-  //     authority: "https://login.microsoftonline.com",
-  //     prompt: "select_account",
-  //   },
-  // } : {},
+  socialProviders: process.env["MICROSOFT_CLIENT_ID"] && process.env["MICROSOFT_CLIENT_SECRET"] ? {
+    microsoft: {
+      clientId: process.env["MICROSOFT_CLIENT_ID"] as string,
+      clientSecret: process.env["MICROSOFT_CLIENT_SECRET"] as string,
+      tenantId: process.env["MICROSOFT_TENANT_ID"] || "common",
+      prompt: "select_account",
+    },
+  } : {},
   session: {
     expiresIn: 86_400 * 7, // 7 days
     updateAge: 86_400, // 1 day

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -21,14 +21,17 @@ export const auth = betterAuth({
     requireEmailVerification: false,
     minPasswordLength: 8,
   },
-  socialProviders: process.env["MICROSOFT_CLIENT_ID"] && process.env["MICROSOFT_CLIENT_SECRET"] ? {
-    microsoft: {
-      clientId: process.env["MICROSOFT_CLIENT_ID"] as string,
-      clientSecret: process.env["MICROSOFT_CLIENT_SECRET"] as string,
-      tenantId: process.env["MICROSOFT_TENANT_ID"] || "common",
-      prompt: "select_account",
-    },
-  } : {},
+  socialProviders:
+    process.env["MICROSOFT_CLIENT_ID"] && process.env["MICROSOFT_CLIENT_SECRET"]
+      ? {
+          microsoft: {
+            clientId: process.env["MICROSOFT_CLIENT_ID"] as string,
+            clientSecret: process.env["MICROSOFT_CLIENT_SECRET"] as string,
+            tenantId: process.env["MICROSOFT_TENANT_ID"] || "common",
+            prompt: "select_account",
+          },
+        }
+      : {},
   session: {
     expiresIn: 86_400 * 7, // 7 days
     updateAge: 86_400, // 1 day

--- a/frontend/src/lib/ui/custom/profile/ProfileOverview.tsx
+++ b/frontend/src/lib/ui/custom/profile/ProfileOverview.tsx
@@ -38,10 +38,6 @@ export function ProfileOverview() {
       >
         <div className="flex flex-col space-y-2 text-left">
           <p className="font-semibold text-sm">{user?.name}</p>
-          <p className="text-sm text-muted-foreground leading-snug">
-            Ortopædkirurgisk <br />
-            Aalborg Universitetshospital
-          </p>
 
           <Button
             variant="default"

--- a/nginx/nginx-init.conf
+++ b/nginx/nginx-init.conf
@@ -1,0 +1,17 @@
+# Temporary config for initial certificate request
+server {
+    listen 80;
+    server_name taletiltekst.syddjurs.dk;
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,36 @@
+server {
+    listen 80;
+    server_name taletiltekst.syddjurs.dk;
+
+    # ACME challenge for certbot
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    # Redirect everything else to HTTPS (once cert exists)
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl;
+    server_name taletiltekst.syddjurs.dk;
+
+    ssl_certificate /etc/nginx/certs/fullchain.pem;
+    ssl_certificate_key /etc/nginx/certs/privkey.pem;
+
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+
+    client_max_body_size 100M;
+
+    location / {
+        proxy_pass http://frontend:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 300s;
+    }
+}

--- a/transcription/Dockerfile
+++ b/transcription/Dockerfile
@@ -7,12 +7,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# Install everything in one pass so pip resolves torch only once
-# (nemo/pyannote may pull a newer torch than the cu124 index default,
-#  a two-step install causes a double download that can exhaust disk)
-RUN pip install --no-cache-dir \
+# Host driver 550.x only supports CUDA 12.4 — cu124 index only has torch<=2.6.
+# pyannote 4.x needs torchaudio>=2.8 (unavailable for cu124), so pin to 3.x.
+# Use constraints to prevent the second pip install from upgrading torch.
+RUN echo 'torch==2.6.0+cu124' > /tmp/constraints.txt && \
+    echo 'torchaudio==2.6.0+cu124' >> /tmp/constraints.txt && \
+    pip install --no-cache-dir \
+    'torch==2.6.0+cu124' \
+    'torchaudio==2.6.0+cu124' \
+    --index-url https://download.pytorch.org/whl/cu124 && \
+    pip install --no-cache-dir \
+    --constraint /tmp/constraints.txt \
     'nemo_toolkit[asr]' \
-    'pyannote.audio' \
+    'pyannote.audio>=3.3,<4.0' \
     fastapi \
     'uvicorn[standard]' \
     python-multipart \

--- a/transcription/main.py
+++ b/transcription/main.py
@@ -54,7 +54,9 @@ async def lifespan(app: FastAPI):
 
     stt_model = os.environ.get("STT_MODEL", "nvidia/parakeet-rnnt-110m-da-dk")
     print(f"Loading STT model: {stt_model}...")
-    model = nemo_asr.models.ASRModel.from_pretrained(
+    # NeMo 2.7+ bug: ASRModel.from_pretrained() fails to resolve the concrete
+    # subclass from config, so we use EncDecRNNTBPEModel directly.
+    model = nemo_asr.models.EncDecRNNTBPEModel.from_pretrained(
         model_name=stt_model
     )
     model.eval()


### PR DESCRIPTION
## Summary
- **Nginx reverse proxy**: Added nginx service with SSL termination, replacing direct port exposure on the frontend. Includes HTTP→HTTPS redirect.
- **Proxy fix**: Strip hop-by-hop headers (`Connection`, `Keep-Alive`, etc.) in the Next.js proxy to fix `undici` errors when running behind a reverse proxy.
- **PDF generation fix**: Added WeasyPrint system dependencies (`libglib2.0`, `libpango`, `libpangocairo`, `libgdk-pixbuf`) to the backend Docker image.
- **Auth**: Added `taletiltekst.syddjurs.dk` (HTTP + HTTPS) to Better Auth `trustedOrigins`.
- **Profile cleanup**: Removed hardcoded department/hospital text from profile dropdown.
- **Transcription**: Pinned torch/torchaudio for CUDA 12.4 compat, fixed NeMo 2.7+ model loading.

## Test plan
- [ ] Verify HTTPS works on taletiltekst.syddjurs.dk with valid certificate
- [ ] Verify HTTP redirects to HTTPS
- [ ] Test audio transcription upload through the reverse proxy
- [ ] Test PDF export from the backend
- [ ] Test Microsoft Entra ID login flow
- [ ] Verify profile dropdown no longer shows hardcoded department