### PR TITLE
fix: save-button dialog (#68), transcription OOM + diarization (#72), trusted-origins env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,8 +25,7 @@ BETTER_AUTH_SECRET=your_better_auth_secret_here
 BETTER_AUTH_URL=http://localhost:3000
 # Comma-separated list of trusted origins for Better Auth.
 # Defaults to http://localhost:3000,http://127.0.0.1:3000 if unset.
-# Production deployments should extend this with their public hostnames, e.g.:
-# TRUSTED_ORIGINS=http://localhost:3000,https://pedro.sikkerai.dk,http://taletiltekst.syddjurs.dk,https://taletiltekst.syddjurs.dk,http://10.1.3.10:6767
+# Add your own deployment's public hostnames here.
 TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # OAuth Configuration (optional)

--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,9 @@ HF_TOKEN=
 # Generate with: openssl rand -base64 32
 BETTER_AUTH_SECRET=your_better_auth_secret_here
 BETTER_AUTH_URL=http://localhost:3000
+# Comma-separated list of trusted origins for Better Auth.
+# Defaults to http://localhost:3000,http://127.0.0.1:3000 if unset.
+TRUSTED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000
 
 # OAuth Configuration (optional)
 MICROSOFT_CLIENT_ID=

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -64,6 +64,7 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-postgres}@postgres:5432/${POSTGRES_DB:-memoctopus}?sslmode=disable
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET:-dev-secret-key-for-local}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
+      TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:3000,http://127.0.0.1:3000}
       BACKEND_URL: http://backend:8000
     ports:
       - "3000:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,6 +98,7 @@ services:
       DATABASE_URL: postgres://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB:-memoctopus}?sslmode=disable
       BETTER_AUTH_SECRET: ${BETTER_AUTH_SECRET}
       BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:3000}
+      TRUSTED_ORIGINS: ${TRUSTED_ORIGINS:-http://localhost:3000,http://127.0.0.1:3000}
       MICROSOFT_CLIENT_ID: ${MICROSOFT_CLIENT_ID:-}
       MICROSOFT_CLIENT_SECRET: ${MICROSOFT_CLIENT_SECRET:-}
       BACKEND_URL: http://backend:8000

--- a/frontend/src/lib/api/transcription.ts
+++ b/frontend/src/lib/api/transcription.ts
@@ -10,7 +10,7 @@ export const transcribeAudio = async ({ file }: TranscribeAudioProps) => {
   formData.append("model", "whisper-1");
 
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 5 * 60 * 1000);
+  const timeoutId = setTimeout(() => controller.abort(), 30 * 60 * 1000);
 
   const res = await fetch(`${API_BASE_URL}/api/v1/audio/transcriptions`, {
     method: "POST",
@@ -21,7 +21,14 @@ export const transcribeAudio = async ({ file }: TranscribeAudioProps) => {
   clearTimeout(timeoutId);
 
   if (!res.ok) {
-    throw new Error("Failed to transcribe audio");
+    let message = "Failed to transcribe audio";
+    try {
+      const body = (await res.json()) as { error?: string };
+      if (body?.error) message = body.error;
+    } catch {
+      // response body wasn't JSON; stick with default message
+    }
+    throw new Error(message);
   }
 
   const result: Promise<{ text: string }> = res.json();

--- a/frontend/src/lib/auth.ts
+++ b/frontend/src/lib/auth.ts
@@ -1,6 +1,20 @@
 import { betterAuth } from "better-auth";
 import { Pool } from "pg";
 
+const DEFAULT_TRUSTED_ORIGINS = [
+  "http://localhost:3000",
+  "http://127.0.0.1:3000",
+];
+
+const parseTrustedOrigins = (raw: string | undefined): string[] => {
+  if (!raw) return DEFAULT_TRUSTED_ORIGINS;
+  const origins = raw
+    .split(",")
+    .map((o) => o.trim())
+    .filter(Boolean);
+  return origins.length > 0 ? origins : DEFAULT_TRUSTED_ORIGINS;
+};
+
 export const auth = betterAuth({
   database: new Pool({
     connectionString: process.env["DATABASE_URL"],
@@ -8,12 +22,7 @@ export const auth = betterAuth({
   secret:
     process.env["BETTER_AUTH_SECRET"] || "fallback-secret-key-for-development",
   baseURL: process.env["BETTER_AUTH_URL"] || "http://localhost:3000",
-  trustedOrigins: [
-    "http://localhost:3000",
-    "http://127.0.0.1:3000",
-    "https://pedro.sikkerai.dk",
-    "http://10.1.3.10:6767",
-  ],
+  trustedOrigins: parseTrustedOrigins(process.env["TRUSTED_ORIGINS"]),
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,

--- a/frontend/src/lib/ui/custom/dialog/PromptDialog.tsx
+++ b/frontend/src/lib/ui/custom/dialog/PromptDialog.tsx
@@ -131,10 +131,7 @@ export const PromptDialog = ({
         </div>
       </DialogTrigger>
 
-      <DialogContent
-        data-row-action
-        className="flex max-h-[90vh] flex-col"
-      >
+      <DialogContent data-row-action className="flex max-h-[90vh] flex-col">
         <DialogHeader>
           <DialogTitle>
             {isEditMode ? "Rediger skabelon" : "Opret ny skabelon"}

--- a/frontend/src/lib/ui/custom/dialog/PromptDialog.tsx
+++ b/frontend/src/lib/ui/custom/dialog/PromptDialog.tsx
@@ -131,14 +131,17 @@ export const PromptDialog = ({
         </div>
       </DialogTrigger>
 
-      <DialogContent data-row-action>
+      <DialogContent
+        data-row-action
+        className="flex max-h-[90vh] flex-col"
+      >
         <DialogHeader>
           <DialogTitle>
             {isEditMode ? "Rediger skabelon" : "Opret ny skabelon"}
           </DialogTitle>
         </DialogHeader>
 
-        <FieldSet>
+        <FieldSet className="min-h-0 flex-1 overflow-y-auto">
           <FieldGroup className="flex flex-col gap-4">
             <Field data-invalid={!!validationErrors?.["name"]}>
               <div className="flex items-center justify-between">

--- a/transcription/Dockerfile
+++ b/transcription/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app
 #  a two-step install causes a double download that can exhaust disk)
 RUN pip install --no-cache-dir \
     'nemo_toolkit[asr]' \
-    'pyannote.audio' \
+    'pyannote.audio>=3.3.2' \
     fastapi \
     'uvicorn[standard]' \
     python-multipart \

--- a/transcription/main.py
+++ b/transcription/main.py
@@ -1,9 +1,22 @@
 import os
+import gc
 import tempfile
 import subprocess
 import asyncio
 from contextlib import asynccontextmanager
 from typing import Optional
+
+# torchaudio removed `set_audio_backend` in 2.1. Older pyannote.audio releases
+# still call it at import time, which breaks diarization loading. Shim as a
+# no-op before any pyannote import so diarization keeps working regardless of
+# which minor version gets resolved at install time.
+try:
+    import torchaudio
+
+    if not hasattr(torchaudio, "set_audio_backend"):
+        torchaudio.set_audio_backend = lambda *args, **kwargs: None
+except Exception as e:
+    print(f"Note: torchaudio shim skipped ({e}).")
 
 # Monkey-patch lhotse CutSampler to work with torch >= 2.10
 # (lhotse 1.31.x passes data_source=None to Sampler.__init__ which torch 2.10 removed)
@@ -126,21 +139,128 @@ def convert_to_wav(input_path: str, output_path: str):
         )
 
 
-def do_transcribe(audio_path: str, timestamps: bool = False) -> dict:
-    """Transcribe audio file. Runs synchronously (call from thread pool).
+# Chunked transcription keeps Conformer self-attention bounded for long audio
+# (#72). Conformer rel-pos attention is O(T²) in sequence length; feeding a
+# multi-hour file in one pass OOMs the GPU.
+CHUNK_LENGTH_S = float(os.environ.get("CHUNK_LENGTH_S", "30"))
+CHUNK_OVERLAP_S = float(os.environ.get("CHUNK_OVERLAP_S", "2"))
+CHUNK_THRESHOLD_S = float(os.environ.get("CHUNK_THRESHOLD_S", "60"))
 
-    Freezes the encoder before transcription to ensure NeMo's
-    freeze/unfreeze lifecycle is satisfied (#63).
+
+def _probe_duration(wav_path: str) -> float:
+    import soundfile as sf
+
+    info = sf.info(wav_path)
+    return float(info.frames) / float(info.samplerate)
+
+
+def _split_wav(
+    wav_path: str, tmpdir: str, chunk_len: float, overlap: float
+) -> list[tuple[str, float]]:
+    """Slice a WAV into overlapping chunk files.
+
+    Returns [(chunk_path, start_seconds), ...]. Chunks are written as
+    16-bit PCM WAVs next to the source file.
     """
-    # Freeze encoder before transcription so NeMo can safely unfreeze it
-    # during _transcribe_on_end. Without this, calling unfreeze(partial=True)
-    # raises ValueError because the module was never frozen.
-    if hasattr(model, "encoder") and hasattr(model.encoder, "freeze"):
-        try:
-            model.encoder.freeze()
-        except Exception:
-            pass  # Already frozen or not applicable
+    import soundfile as sf
 
+    info = sf.info(wav_path)
+    sr = info.samplerate
+    total_frames = info.frames
+    chunk_frames = int(chunk_len * sr)
+    step_frames = int(max(chunk_len - overlap, 0.1) * sr)
+
+    chunks: list[tuple[str, float]] = []
+    start_frame = 0
+    idx = 0
+    while start_frame < total_frames:
+        frames_to_read = min(chunk_frames, total_frames - start_frame)
+        data, _ = sf.read(
+            wav_path,
+            start=start_frame,
+            frames=frames_to_read,
+            dtype="float32",
+            always_2d=False,
+        )
+        chunk_path = os.path.join(tmpdir, f"chunk_{idx:05d}.wav")
+        sf.write(chunk_path, data, sr, subtype="PCM_16")
+        chunks.append((chunk_path, start_frame / sr))
+        if start_frame + frames_to_read >= total_frames:
+            break
+        start_frame += step_frames
+        idx += 1
+    return chunks
+
+
+def _merge_chunk_results(
+    chunk_results: list[dict], chunk_starts: list[float], overlap: float
+) -> dict:
+    """Merge per-chunk transcriptions with timestamp shifting and overlap dedup.
+
+    Each chunk's timestamps are offset to absolute time, then words/segments
+    falling in an overlap window are assigned to one chunk using the
+    midpoint rule (midpoint between consecutive chunks = start_{i+1} + overlap/2).
+    Text is rebuilt from the merged word list to guarantee no duplication.
+    """
+    n = len(chunk_results)
+    # Boundaries in absolute seconds. `bounds[i]` is the left edge of chunk i's
+    # owned range; `bounds[i+1]` is its right edge. First left = -inf,
+    # last right = +inf.
+    bounds: list[float] = [float("-inf")]
+    for i in range(n - 1):
+        bounds.append(chunk_starts[i + 1] + overlap / 2.0)
+    bounds.append(float("inf"))
+
+    merged_word_timestamps: list[dict] = []
+    merged_words: list[dict] = []
+    merged_segments: list[dict] = []
+
+    for i, result in enumerate(chunk_results):
+        offset = chunk_starts[i]
+        left, right = bounds[i], bounds[i + 1]
+
+        wts_src = result.get("word_timestamps", []) or []
+        words_src = result.get("words", []) or []
+        segments_src = result.get("segments", []) or []
+        aligned = len(words_src) == len(wts_src)
+
+        for j, wt in enumerate(wts_src):
+            abs_start = float(wt.get("start", 0)) + offset
+            abs_end = float(wt.get("end", 0)) + offset
+            mid = (abs_start + abs_end) / 2.0
+            if mid < left or mid >= right:
+                continue
+            merged_word_timestamps.append({**wt, "start": abs_start, "end": abs_end})
+            if aligned:
+                merged_words.append(words_src[j])
+
+        for seg in segments_src:
+            abs_start = float(seg.get("start", 0)) + offset
+            abs_end = float(seg.get("end", 0)) + offset
+            mid = (abs_start + abs_end) / 2.0
+            if mid < left or mid >= right:
+                continue
+            merged_segments.append({**seg, "start": abs_start, "end": abs_end})
+
+    text = " ".join(
+        str(wt.get("word", "")).strip()
+        for wt in merged_word_timestamps
+        if str(wt.get("word", "")).strip()
+    )
+
+    merged: dict = {"text": text}
+    if merged_words:
+        merged["words"] = merged_words
+    if merged_word_timestamps:
+        merged["word_timestamps"] = merged_word_timestamps
+    if merged_segments:
+        merged["segments"] = merged_segments
+    return merged
+
+
+def _transcribe_one(audio_path: str, timestamps: bool) -> dict:
+    """Single-pass NeMo transcription. Used directly for short audio and as
+    the per-chunk primitive for long audio."""
     output = model.transcribe(
         [audio_path], return_hypotheses=timestamps, timestamps=timestamps
     )
@@ -154,21 +274,23 @@ def do_transcribe(audio_path: str, timestamps: bool = False) -> dict:
     if isinstance(hyp, list):
         hyp = hyp[0]
 
-    result = {"text": hyp.text}
+    result: dict = {"text": hyp.text}
 
-    # Word-level timestamps and confidence
     if hasattr(hyp, "words") and hyp.words:
         words = []
         confidences_raw = getattr(hyp, "word_confidence", None)
-        confidences = list(confidences_raw) if confidences_raw is not None and len(confidences_raw) > 0 else []
+        confidences = (
+            list(confidences_raw)
+            if confidences_raw is not None and len(confidences_raw) > 0
+            else []
+        )
         for i, word in enumerate(hyp.words):
-            entry = {"word": word}
+            entry: dict = {"word": word}
             if i < len(confidences):
                 entry["confidence"] = round(confidences[i], 3)
             words.append(entry)
         result["words"] = words
 
-    # Timestamp dict (segment/word/char level)
     ts = getattr(hyp, "timestamp", None) or getattr(hyp, "timestep", None)
     if ts and isinstance(ts, dict):
         if "segment" in ts:
@@ -177,6 +299,57 @@ def do_transcribe(audio_path: str, timestamps: bool = False) -> dict:
             result["word_timestamps"] = ts["word"]
 
     return result
+
+
+def do_transcribe(audio_path: str, timestamps: bool = False) -> dict:
+    """Transcribe audio file. Runs synchronously (call from thread pool).
+
+    Freezes the encoder before transcription to satisfy NeMo's
+    freeze/unfreeze lifecycle (#63). For audio longer than CHUNK_THRESHOLD_S,
+    splits into overlapping windows and transcribes sequentially to avoid
+    Conformer self-attention OOM (#72).
+    """
+    # Freeze encoder before transcription so NeMo can safely unfreeze it
+    # during _transcribe_on_end.
+    if hasattr(model, "encoder") and hasattr(model.encoder, "freeze"):
+        try:
+            model.encoder.freeze()
+        except Exception:
+            pass  # Already frozen or not applicable
+
+    try:
+        duration = _probe_duration(audio_path)
+    except Exception as e:
+        print(f"Note: could not probe audio duration ({e}); using single-pass path.")
+        return _transcribe_one(audio_path, timestamps)
+
+    if duration <= CHUNK_THRESHOLD_S:
+        return _transcribe_one(audio_path, timestamps)
+
+    import torch
+
+    with tempfile.TemporaryDirectory() as chunk_dir:
+        chunks = _split_wav(audio_path, chunk_dir, CHUNK_LENGTH_S, CHUNK_OVERLAP_S)
+        if not chunks:
+            return _transcribe_one(audio_path, timestamps)
+
+        chunk_results: list[dict] = []
+        chunk_starts: list[float] = []
+        for idx, (chunk_path, start_sec) in enumerate(chunks):
+            # Request timestamps per chunk so we can dedup overlap, even if
+            # the caller didn't ask for them.
+            chunk_results.append(_transcribe_one(chunk_path, True))
+            chunk_starts.append(start_sec)
+            if torch.cuda.is_available():
+                torch.cuda.empty_cache()
+            if (idx + 1) % 8 == 0:
+                gc.collect()
+
+    merged = _merge_chunk_results(chunk_results, chunk_starts, CHUNK_OVERLAP_S)
+    if not timestamps:
+        # Match the short-file contract: only `text` when timestamps not requested.
+        return {"text": merged.get("text", "")}
+    return merged
 
 
 def do_diarize(audio_path: str) -> list[dict]:
@@ -320,58 +493,68 @@ async def transcribe(
 
         loop = asyncio.get_event_loop()
 
-        if diarization_pipeline is not None:
-            # Run transcription (with timestamps) and diarization in parallel
-            transcribe_future = loop.run_in_executor(
-                None, do_transcribe, wav_path, True
-            )
-            diarize_future = loop.run_in_executor(
-                None, do_diarize, wav_path
-            )
+        try:
+            if diarization_pipeline is not None:
+                # Serialize diarization then ASR to keep GPU peak predictable
+                # across hardware tiers (#72). Diarization output is small, so
+                # its footprint is negligible once it finishes.
+                diarization_segments = await loop.run_in_executor(
+                    None, do_diarize, wav_path
+                )
+                transcription_result = await loop.run_in_executor(
+                    None, do_transcribe, wav_path, True
+                )
 
-            transcription_result, diarization_segments = await asyncio.gather(
-                transcribe_future, diarize_future
-            )
+                try:
+                    merged_text = merge_transcription_and_diarization(
+                        transcription_result, diarization_segments
+                    )
+                except Exception as e:
+                    print(f"Warning: Diarization merge failed: {e}")
+                    merged_text = transcription_result.get("text", "")
 
-            # Merge transcription with speaker labels
+                result = {"text": merged_text}
+
+                if want_timestamps:
+                    for key in ("words", "segments", "word_timestamps"):
+                        if key in transcription_result:
+                            result[key] = transcription_result[key]
+            else:
+                result = await loop.run_in_executor(
+                    None, do_transcribe, wav_path, want_timestamps
+                )
+        except RuntimeError as e:
+            # Covers torch.cuda.OutOfMemoryError (subclass of RuntimeError in
+            # torch 2.1+). Release allocator blocks and return a structured
+            # 413 so the frontend can render an actionable message instead
+            # of a generic 500 (#72).
+            if "out of memory" not in str(e).lower():
+                raise
             try:
-                merged_text = merge_transcription_and_diarization(
-                    transcription_result, diarization_segments
-                )
-            except Exception as e:
-                print(f"Warning: Diarization merge failed: {e}")
-                merged_text = transcription_result.get("text", "")
+                import torch
 
-            result = {"text": merged_text}
-
-            # Include raw timestamps if explicitly requested
-            if want_timestamps:
-                for key in ("words", "segments", "word_timestamps"):
-                    if key in transcription_result:
-                        result[key] = transcription_result[key]
-
-            # Validate non-empty transcription (#62)
-            if not result.get("text", "").strip():
-                return JSONResponse(
-                    content={"error": "Transcription produced empty output. The audio may be silent or unrecognizable."},
-                    status_code=422,
-                )
-
-            return JSONResponse(content=result)
-        else:
-            # No diarization — plain transcription
-            result = await loop.run_in_executor(
-                None, do_transcribe, wav_path, want_timestamps
+                if torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:
+                pass
+            return JSONResponse(
+                content={
+                    "error": (
+                        "Audio too long to transcribe on this GPU. "
+                        "Try a shorter file or lower CHUNK_LENGTH_S."
+                    )
+                },
+                status_code=413,
             )
 
-            # Validate non-empty transcription (#62)
-            if not result.get("text", "").strip():
-                return JSONResponse(
-                    content={"error": "Transcription produced empty output. The audio may be silent or unrecognizable."},
-                    status_code=422,
-                )
+        # Validate non-empty transcription (#62)
+        if not result.get("text", "").strip():
+            return JSONResponse(
+                content={"error": "Transcription produced empty output. The audio may be silent or unrecognizable."},
+                status_code=422,
+            )
 
-            return JSONResponse(content=result)
+        return JSONResponse(content=result)
 
 
 @app.get("/health")

--- a/transcription/tests/test_issue_72_chunking.py
+++ b/transcription/tests/test_issue_72_chunking.py
@@ -1,0 +1,166 @@
+"""
+Tests for Issue #72: chunked transcription of long audio.
+
+The transcription service has heavy NeMo/torch/pyannote dependencies that
+aren't installed in the dev env, so we re-import the pure-python helpers
+from transcription.main inline (mirrors the pattern used by
+backend/tests/test_issue_62_transcription_service.py).
+"""
+
+import os
+import sys
+
+import pytest
+
+HERE = os.path.dirname(__file__)
+sys.path.insert(0, os.path.abspath(os.path.join(HERE, "..")))
+
+
+def _merge_chunk_results(chunk_results, chunk_starts, overlap):
+    """Copied from transcription/main.py to test without importing the module
+    (which pulls torch, nemo, pyannote)."""
+    n = len(chunk_results)
+    bounds = [float("-inf")]
+    for i in range(n - 1):
+        bounds.append(chunk_starts[i + 1] + overlap / 2.0)
+    bounds.append(float("inf"))
+
+    merged_word_timestamps = []
+    merged_words = []
+    merged_segments = []
+
+    for i, result in enumerate(chunk_results):
+        offset = chunk_starts[i]
+        left, right = bounds[i], bounds[i + 1]
+
+        wts_src = result.get("word_timestamps", []) or []
+        words_src = result.get("words", []) or []
+        segments_src = result.get("segments", []) or []
+        aligned = len(words_src) == len(wts_src)
+
+        for j, wt in enumerate(wts_src):
+            abs_start = float(wt.get("start", 0)) + offset
+            abs_end = float(wt.get("end", 0)) + offset
+            mid = (abs_start + abs_end) / 2.0
+            if mid < left or mid >= right:
+                continue
+            merged_word_timestamps.append({**wt, "start": abs_start, "end": abs_end})
+            if aligned:
+                merged_words.append(words_src[j])
+
+        for seg in segments_src:
+            abs_start = float(seg.get("start", 0)) + offset
+            abs_end = float(seg.get("end", 0)) + offset
+            mid = (abs_start + abs_end) / 2.0
+            if mid < left or mid >= right:
+                continue
+            merged_segments.append({**seg, "start": abs_start, "end": abs_end})
+
+    text = " ".join(
+        str(wt.get("word", "")).strip()
+        for wt in merged_word_timestamps
+        if str(wt.get("word", "")).strip()
+    )
+
+    merged = {"text": text}
+    if merged_words:
+        merged["words"] = merged_words
+    if merged_word_timestamps:
+        merged["word_timestamps"] = merged_word_timestamps
+    if merged_segments:
+        merged["segments"] = merged_segments
+    return merged
+
+
+def _chunk(words):
+    """Build a chunk result dict from [(word, start, end), ...]."""
+    return {
+        "text": " ".join(w for w, _, _ in words),
+        "words": [{"word": w} for w, _, _ in words],
+        "word_timestamps": [
+            {"word": w, "start": s, "end": e} for w, s, e in words
+        ],
+        "segments": [
+            {"start": words[0][1], "end": words[-1][2]}
+        ] if words else [],
+    }
+
+
+def test_merge_shifts_and_preserves_order():
+    """Timestamps in merged output should equal chunk_start + local_timestamp
+    and be strictly monotonic. Words in chunk B placed past the midpoint
+    (local > 1.0s, since chunk_starts=[0,28], overlap=2 → midpoint=29s) so
+    they're not dropped as overlap."""
+    chunk_a = _chunk([("hello", 0.0, 0.5), ("world", 0.6, 1.1)])
+    chunk_b = _chunk([("how", 2.0, 2.3), ("are", 2.4, 2.7), ("you", 2.8, 3.0)])
+
+    merged = _merge_chunk_results([chunk_a, chunk_b], [0.0, 28.0], overlap=2.0)
+
+    starts = [w["start"] for w in merged["word_timestamps"]]
+    assert starts == sorted(starts)
+    assert merged["word_timestamps"][0]["start"] == pytest.approx(0.0)
+    assert merged["word_timestamps"][-1]["end"] == pytest.approx(31.0)
+    assert merged["text"].startswith("hello")
+    assert merged["text"].endswith("you")
+
+
+def test_overlap_midpoint_keeps_each_word_exactly_once():
+    """Chunks cover [0, 30] and [28, 58] with 2s overlap. The midpoint
+    between them is 29s. A word in the overlap region should survive in
+    exactly one chunk, not both."""
+    # Chunk A covers 0..30 in absolute time; the last word straddles into
+    # the overlap at 28.5..29.2 (midpoint 28.85 — BEFORE the 29s midpoint,
+    # so it belongs to chunk A).
+    chunk_a = _chunk([
+        ("early", 0.0, 0.5),
+        ("later", 28.5, 29.2),  # abs midpoint 28.85 → kept in A
+    ])
+    # Chunk B starts at 28. Its local 0..0.7 corresponds to abs 28..28.7.
+    # Any word with local end < 1.0 (abs < 29.0) has midpoint < 29 — so
+    # it belongs to A's range and must be dropped from B's contribution.
+    chunk_b = _chunk([
+        ("later", 0.5, 1.2),  # abs mid (28.5+29.2)/2 = 28.85 → drop from B
+        ("after", 2.0, 2.5),  # abs mid 30.25 → kept in B
+    ])
+
+    merged = _merge_chunk_results([chunk_a, chunk_b], [0.0, 28.0], overlap=2.0)
+
+    texts = [w["word"] for w in merged["word_timestamps"]]
+    assert texts.count("later") == 1, (
+        f"overlap word duplicated: {texts}"
+    )
+    assert texts == ["early", "later", "after"]
+
+
+def test_single_chunk_roundtrips_without_dedup():
+    chunk_a = _chunk([("one", 0.0, 0.4), ("two", 0.5, 0.9)])
+    merged = _merge_chunk_results([chunk_a], [0.0], overlap=2.0)
+    assert len(merged["word_timestamps"]) == 2
+    assert merged["text"] == "one two"
+
+
+def test_words_and_word_timestamps_stay_index_aligned():
+    """When per-chunk `words` and `word_timestamps` have the same length,
+    the merge must drop/keep them with the same mask so downstream
+    consumers can zip them."""
+    chunk_a = _chunk([("a", 0.0, 0.5), ("b", 29.5, 29.9)])  # b mid 29.7 > 29 → drop from A
+    chunk_b = _chunk([("b", 1.5, 1.9), ("c", 3.0, 3.4)])    # b mid 29.7 → kept in B
+
+    merged = _merge_chunk_results([chunk_a, chunk_b], [0.0, 28.0], overlap=2.0)
+
+    assert len(merged["words"]) == len(merged["word_timestamps"])
+    assert [w["word"] for w in merged["words"]] == ["a", "b", "c"]
+
+
+def test_segments_are_shifted_and_deduped():
+    chunk_a = _chunk([("x", 1.0, 29.0)])  # segment spans 1..29, mid=15 → A
+    chunk_b = _chunk([("y", 0.5, 1.5)])   # abs 28.5..29.5, mid=29 → B (mid >= right bound? right=29 → drop)
+    merged = _merge_chunk_results([chunk_a, chunk_b], [0.0, 28.0], overlap=2.0)
+    # At least one non-overlapping segment should survive without duplication
+    assert len(merged["segments"]) >= 1
+    assert all(s["start"] < s["end"] for s in merged["segments"])
+
+
+def test_empty_input_yields_empty_result():
+    merged = _merge_chunk_results([], [], overlap=2.0)
+    assert merged == {"text": ""}


### PR DESCRIPTION
## Summary

Three independent fixes bundled — happy to split on request.

- **#68 Prompt dialog Save button** — cap `DialogContent` at `90vh` and make the form body scroll internally so the footer stays anchored no matter how long the textarea grows.
- **#72 Large-audio transcription OOM + diarization disabled** — split audio >60s into 30s/2s-overlap windows and run NeMo sequentially; restore pyannote loading on torchaudio ≥ 2.1 via version pin + import-time shim; serialize diarize→ASR; OOMs now return structured 413. Frontend timeout bumped to 30min and surfaces server error messages.
- **Trusted origins env var** — replace hardcoded `trustedOrigins` list with `TRUSTED_ORIGINS` (comma-separated); defaults to localhost. Wired through both docker-compose files.

⚠️ The old hardcoded entries (`pedro.sikkerai.dk`, `10.1.3.10:6767`) are gone from the default. **Prod `.env` must set `TRUSTED_ORIGINS`** to include them before this merges, or Better Auth will reject those origins.

## Commits

1. `fix: keep Save button visible in long prompt dialogs (#68)`
2. `feat: read Better Auth trusted origins from env`
3. `fix: chunk long audio to avoid transcription OOM + restore diarization (#72)`

## Test plan

- [ ] Prompt dialog: open with 1500+ char prompt, confirm Save stays visible and form body scrolls.
- [ ] Trusted origins: deploy with `TRUSTED_ORIGINS` set to prod origins, confirm sign-in still works from each; unset to confirm localhost fallback.
- [ ] Transcription OOM: upload a 90min file, expect 200 + coherent text + speaker labels in ≤ wall clock budget. Watch pod logs for `Pyannote diarization pipeline loaded successfully.` at startup and sequential `Transcribing: Nit` per chunk instead of a single OOM.
- [ ] Transcription short path: upload a <60s file, confirm it still uses the single-pass path (no chunking overhead).
- [ ] Frontend error surface: force a 413 from the transcription service, confirm the error message shows the server's text instead of "Failed to transcribe".
- [ ] `pytest transcription/tests/ backend/tests/` → all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)