### PR TITLE
fix: use undici for diarization uploads (conflict-free rebranch of #89)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,6 +39,7 @@
         "react-markdown": "^10.1.0",
         "tailwind-merge": "^2.6.0",
         "tiptap-markdown": "^0.9.0",
+        "undici": "^8.5.0",
         "zod": "^3.24.4"
       },
       "devDependencies": {
@@ -6601,6 +6602,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/jsdom/node_modules/undici": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/jsdom/node_modules/webidl-conversions": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
@@ -9357,13 +9368,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "7.25.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
-      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
-      "dev": true,
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "react-markdown": "^10.1.0",
     "tailwind-merge": "^2.6.0",
     "tiptap-markdown": "^0.9.0",
+    "undici": "^8.5.0",
     "zod": "^3.24.4"
   },
   "devDependencies": {

--- a/src/lib/ai/diarization.test.ts
+++ b/src/lib/ai/diarization.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockDecode = vi.hoisted(() => vi.fn());
 const mockEncode = vi.hoisted(() => vi.fn());
+const mockUndiciFetch = vi.hoisted(() => vi.fn());
+
+vi.mock('undici', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('undici')>();
+
+  return {
+    ...actual,
+    fetch: mockUndiciFetch,
+  };
+});
 
 vi.mock('@/lib/audio/decode-server', () => ({
   decodeToMono16k: mockDecode,
@@ -18,27 +28,33 @@ import {
 
 const ENV = process.env;
 
+type FormLike = {
+  get(name: string): unknown;
+};
+
+type UploadedFileLike = {
+  type?: string;
+  name?: string;
+};
+
 function jsonResponse(body: unknown, ok = true, status = 200): Response {
   return {
     ok,
     status,
     json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
   } as Response;
 }
 
-let mockFetch: ReturnType<typeof vi.fn>;
-
 beforeEach(() => {
   process.env = { ...ENV };
-  mockFetch = vi.fn();
-  vi.stubGlobal('fetch', mockFetch);
+  mockUndiciFetch.mockReset();
   mockDecode.mockReset();
   mockEncode.mockReset();
 });
 
 afterEach(() => {
   process.env = ENV;
-  vi.unstubAllGlobals();
   setDiarizationProvider(null as never); // reset the singleton between tests
 });
 
@@ -51,113 +67,152 @@ describe('PyannoteProvider.diarize', () => {
       { speaker: 'SPEAKER_00', start: 0, end: 2 },
       { speaker: 'SPEAKER_01', start: 2, end: 4 },
     ];
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns }));
+
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns }));
 
     const result = await new PyannoteProvider().diarize(buf, 'audio/wav');
 
     expect(result).toEqual(turns);
-    const [url, init] = mockFetch.mock.calls[0];
+
+    const [url, init] = mockUndiciFetch.mock.calls[0];
     expect(url).toBe('http://diar:5000/diarize');
     expect(init.method).toBe('POST');
-    expect(init.body).toBeInstanceOf(FormData);
+    expect(init.body).toBeDefined();
+    expect(typeof (init.body as FormLike).get).toBe('function');
+    expect(init.dispatcher).toBeDefined();
+    expect(init.signal).toBeDefined();
   });
 
   it('strips a trailing slash from DIARIZATION_URL', async () => {
     process.env.DIARIZATION_URL = 'http://diar:5000/';
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
     await new PyannoteProvider().diarize(buf, 'audio/wav');
-    expect(mockFetch.mock.calls[0][0]).toBe('http://diar:5000/diarize');
+
+    expect(mockUndiciFetch.mock.calls[0][0]).toBe('http://diar:5000/diarize');
   });
 
   it('sends a bearer Authorization header when DIARIZATION_API_KEY is set', async () => {
     process.env.DIARIZATION_API_KEY = 'secret';
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
     await new PyannoteProvider().diarize(buf, 'audio/wav');
-    expect(mockFetch.mock.calls[0][1].headers).toEqual({ Authorization: 'Bearer secret' });
+
+    expect(mockUndiciFetch.mock.calls[0][1].headers).toEqual({
+      Authorization: 'Bearer secret',
+    });
   });
 
   it('omits the Authorization header when DIARIZATION_API_KEY is unset', async () => {
     delete process.env.DIARIZATION_API_KEY;
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
     await new PyannoteProvider().diarize(buf, 'audio/wav');
-    expect(mockFetch.mock.calls[0][1].headers).toBeUndefined();
+
+    expect(mockUndiciFetch.mock.calls[0][1].headers).toBeUndefined();
   });
 
   it('no-ops to [] without fetching when ensemble mode (HVISKE_DIARIZE=true) is on', async () => {
     process.env.HVISKE_DIARIZE = 'true';
     const result = await new PyannoteProvider().diarize(buf, 'audio/webm');
     expect(result).toEqual([]);
-    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockUndiciFetch).not.toHaveBeenCalled();
     expect(mockDecode).not.toHaveBeenCalled();
   });
 
   it('returns [] when the response body has no turns array', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({}));
+
     expect(await new PyannoteProvider().diarize(buf, 'audio/wav')).toEqual([]);
   });
 
   it('returns [] when turns is not an array', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: null }));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: null }));
+
     expect(await new PyannoteProvider().diarize(buf, 'audio/wav')).toEqual([]);
   });
 
   it('throws when the service responds non-ok (so the route can fail-soft)', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({}, false, 502));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({}, false, 502));
+
     await expect(new PyannoteProvider().diarize(buf, 'audio/wav')).rejects.toThrow('502');
   });
 
+  it('includes the response body when the service responds non-ok', async () => {
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse('missing file', false, 422));
+
+    await expect(new PyannoteProvider().diarize(buf, 'audio/wav')).rejects.toThrow(
+      'Diarization service returned 422: missing file',
+    );
+  });
+
   it('does NOT decode when the input is already WAV', async () => {
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+
     await new PyannoteProvider().diarize(buf, 'audio/wav');
+
     expect(mockDecode).not.toHaveBeenCalled();
   });
 
   it('decodes compressed audio to WAV before forwarding to the service', async () => {
     const decoded = new Float32Array([0, 0.5, -0.5]);
     const wav = Buffer.from('RIFFwav');
+
     mockDecode.mockResolvedValueOnce(decoded);
     mockEncode.mockReturnValueOnce(wav);
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
 
     await new PyannoteProvider().diarize(buf, 'audio/webm');
 
     expect(mockDecode).toHaveBeenCalledOnce();
     expect(mockDecode.mock.calls[0][0]).toBe(buf);
     expect(mockEncode).toHaveBeenCalledWith(decoded);
+
     // The forwarded file is the WAV, named with a .wav extension.
-    const form = mockFetch.mock.calls[0][1].body as FormData;
-    const file = form.get('file') as File;
+    const form = mockUndiciFetch.mock.calls[0][1].body as FormLike;
+    const file = form.get('file') as UploadedFileLike;
+
     expect(file.type).toBe('audio/wav');
     expect(file.name).toBe('audio.wav');
   });
 
   it('falls back to the original audio when server-side decode fails', async () => {
     mockDecode.mockRejectedValueOnce(new Error('ffmpeg missing'));
-    mockFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
+    mockUndiciFetch.mockResolvedValueOnce(jsonResponse({ turns: [] }));
 
     await new PyannoteProvider().diarize(buf, 'audio/webm');
 
-    // Still POSTs (the service may be able to decode it itself); does not throw.
-    expect(mockFetch).toHaveBeenCalledOnce();
-    const form = mockFetch.mock.calls[0][1].body as FormData;
-    expect((form.get('file') as File).type).toBe('audio/webm');
+    // Still POSTs; the service may be able to decode it itself. Does not throw.
+    expect(mockUndiciFetch).toHaveBeenCalledOnce();
+
+    const form = mockUndiciFetch.mock.calls[0][1].body as FormLike;
+    const file = form.get('file') as UploadedFileLike;
+
+    expect(file.type).toBe('audio/webm');
   });
 });
 
 describe('getDiarizationProvider / setDiarizationProvider', () => {
   it('returns a PyannoteProvider by default', () => {
     setDiarizationProvider(null as never);
+
     expect(getDiarizationProvider()).toBeInstanceOf(PyannoteProvider);
   });
 
   it('returns the injected provider after setDiarizationProvider', () => {
     const stub: DiarizationProvider = { diarize: vi.fn(async () => []) };
+
     setDiarizationProvider(stub);
+
     expect(getDiarizationProvider()).toBe(stub);
   });
 
   it('memoises the provider instance across calls', () => {
     setDiarizationProvider(null as never);
+
     expect(getDiarizationProvider()).toBe(getDiarizationProvider());
   });
 });

--- a/src/lib/ai/diarization.ts
+++ b/src/lib/ai/diarization.ts
@@ -1,5 +1,6 @@
 import { Buffer } from 'node:buffer';
 import { mimeTypeToExt } from './mime';
+import { Agent, FormData, fetch as undiciFetch } from 'undici';
 import { decodeToMono16k, encodeMono16kWav } from '@/lib/audio/decode-server';
 import { isEnsembleDiarization, hviskeBaseURL } from './transcription';
 
@@ -23,6 +24,10 @@ function getDiarizationTimeoutMs(): number {
   const value = Number(process.env.DIARIZATION_TIMEOUT_MS);
   return Number.isFinite(value) && value > 0 ? value : 300_000;
 }
+
+type FetchInitWithDispatcher = Parameters<typeof undiciFetch>[1] & {
+  dispatcher: Agent;
+};
 
 // ─── pyannote implementation ──────────────────────────────────────────────────
 // Talks to the pyannote.audio diarization service (FastAPI wrapper around
@@ -71,25 +76,53 @@ export class PyannoteProvider implements DiarizationProvider {
     }
 
     const ext = mimeTypeToExt(outMime, 'wav');
-    const file = new File([new Uint8Array(buffer)], `audio.${ext}`, { type: outMime });
     const form = new FormData();
+    const blob = new Blob([new Uint8Array(buffer)], { type: outMime });
+
     // Multipart field name is `file` — the co-hosted hviske /diarize endpoint
     // requires it (the legacy standalone service accepted `audio`; it now accepts
     // both, see diarization-service/app.py).
-    form.append('file', file);
+    //
+    // Use undici.FormData together with undici.fetch. Mixing global FormData/File
+    // with undici.fetch can produce a request that reaches FastAPI but is parsed as
+    // missing the uploaded file.
+    form.append('file', blob, `audio.${ext}`);
 
-    const res = await fetch(`${this.baseURL}/diarize`, {
-      method: 'POST',
-      headers: this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : undefined,
-      body: form,
-      signal: AbortSignal.timeout(getDiarizationTimeoutMs()),
+    const timeoutMs = getDiarizationTimeoutMs();
+
+    // Use undici.fetch together with undici.Agent. Passing an undici dispatcher to
+    // Next/Node's patched global fetch can fail with UND_ERR_INVALID_ARG.
+    //
+    // AbortSignal.timeout controls our own request timeout, but undici also has
+    // headers/body timers. CPU diarization can legitimately take longer than the
+    // default headers timeout before returning response headers, so configure those
+    // timers to match DIARIZATION_TIMEOUT_MS.
+    const dispatcher = new Agent({
+      headersTimeout: timeoutMs,
+      bodyTimeout: timeoutMs,
     });
-    if (!res.ok) {
-      throw new Error(`Diarization service returned ${res.status}`);
-    }
 
-    const data = (await res.json()) as { turns?: SpeakerTurn[] };
-    return Array.isArray(data.turns) ? data.turns : [];
+    try {
+      const res = await undiciFetch(`${this.baseURL}/diarize`, {
+        method: 'POST',
+        headers: this.apiKey ? { Authorization: `Bearer ${this.apiKey}` } : undefined,
+        body: form,
+        signal: AbortSignal.timeout(timeoutMs),
+        dispatcher,
+      } as FetchInitWithDispatcher);
+
+      if (!res.ok) {
+        const body = await res.text().catch(() => '');
+        throw new Error(
+          `Diarization service returned ${res.status}${body ? `: ${body.slice(0, 1000)}` : ''}`,
+        );
+      }
+
+      const data = (await res.json()) as { turns?: SpeakerTurn[] };
+      return Array.isArray(data.turns) ? data.turns : [];
+    } finally {
+      await dispatcher.close();
+    }
   }
 }
 


### PR DESCRIPTION
Same change as #89, branched off that PR's head and merged with `referat-migration-v2` so it applies cleanly.

#89 could not be updated in place: its head lives on the `HJK-Automatisering` fork with *Allow edits by maintainers* off, so nobody here can push the conflict resolution onto it.

### Stacking
#89 was stacked on #88, so this branch contains that commit too — it supersedes both. Merging this one alone delivers both fixes; merging #94 first is also fine, this then reduces to just the undici commit.

### Conflict resolved
`Dockerfile`, one hunk — inherited from the #88 commit, identical to the resolution in #94. The base branch removed the `NEXT_PUBLIC_EMAIL_PASSWORD_ENABLED` / `NEXT_PUBLIC_MICROSOFT_ENABLED` / `NEXT_PUBLIC_AUTHENTIK_ENABLED` build args (auth providers now resolve server-side per request, see `src/lib/auth/providers.ts`); the stacked timeout commit had added `NEXT_PUBLIC_DIARIZATION_TIMEOUT_MS` alongside them. Kept both intents:

```dockerfile
ARG NEXT_PUBLIC_APP_URL=http://localhost:8080
ARG NEXT_PUBLIC_DIARIZATION_TIMEOUT_MS=300000
ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL \
    NEXT_PUBLIC_DIARIZATION_TIMEOUT_MS=$NEXT_PUBLIC_DIARIZATION_TIMEOUT_MS
```

The undici commit itself (`package.json`, `package-lock.json`, `src/lib/ai/diarization.ts`, `src/lib/ai/diarization.test.ts`) auto-merged with no conflicts. No behavioural change beyond what #89 already proposed.

### Verified
- `npx tsc --noEmit` clean
- `npx vitest run` — 46 files, 537 tests, all passing

Closes #89 once merged.